### PR TITLE
Update (the only) withdrawn code in the country codelist

### DIFF
--- a/xml/Country.xml
+++ b/xml/Country.xml
@@ -1127,7 +1127,7 @@
         <codelist-item status="withdrawn">
             <code>AN</code>
             <name>
-                <narrative>NETHERLAND ANTILLES</narrative>
+                <narrative>Netherlands Antilles</narrative>
             </name>
         </codelist-item>
         <codelist-item>

--- a/xml/Country.xml
+++ b/xml/Country.xml
@@ -1128,6 +1128,7 @@
             <code>AN</code>
             <name>
                 <narrative>Netherlands Antilles</narrative>
+                <narrative xml:lang="fr">Antilles néerlandaises (les )</narrative>
             </name>
         </codelist-item>
         <codelist-item>


### PR DESCRIPTION
There’s currently just one withdrawn code in the replicated country codelist. This one:
https://www.iso.org/obp/ui/#iso:code:3166:AN

This PR updates the English name to match the source, and adds the French name from the source.